### PR TITLE
fix(ircclient): use format verbs instead of string concatenation in fmt.Fprintf

### DIFF
--- a/ircclient/commands.go
+++ b/ircclient/commands.go
@@ -9,38 +9,38 @@ import (
 )
 
 func SetNick(conn net.Conn, nick string) error {
-	_, err := fmt.Fprintf(conn, "NICK "+nick+"\r\n")
+	_, err := fmt.Fprintf(conn, "NICK %s\r\n", nick)
 	log.Println("Set nick to ", nick)
 	return err
 }
 
 func JoinChannel(conn net.Conn, channel string) error {
-	_, err := fmt.Fprintf(conn, "JOIN "+channel+"\r\n")
+	_, err := fmt.Fprintf(conn, "JOIN %s\r\n", channel)
 	log.Println("JOIN command sent for channel: ", channel)
 	return err
 }
 
 func PartChannel(conn net.Conn, channel string) error {
-	_, err := fmt.Fprintf(conn, "PART "+channel+"\r\n")
+	_, err := fmt.Fprintf(conn, "PART %s\r\n", channel)
 	log.Println("PART command sent for channel: ", channel)
 	return err
 }
 
 func SetMode(conn net.Conn, channel string, mode string) error {
-	_, err := fmt.Fprintf(conn, "MODE "+channel+" "+mode+"\r\n")
+	_, err := fmt.Fprintf(conn, "MODE %s %s\r\n", channel, mode)
 	log.Println("MODE command sent for target: ", channel, " with mode: ", mode)
 	return err
 }
 
 func SetTopic(conn net.Conn, channel string, topic string) error {
 	cleanTopic := goutilsstrings.StripNewlines(topic)
-	_, err := fmt.Fprintf(conn, "TOPIC "+channel+" "+cleanTopic+"\r\n")
+	_, err := fmt.Fprintf(conn, "TOPIC %s %s\r\n", channel, cleanTopic)
 	log.Println("TOPIC command sent for channel: ", channel, " with topic: ", cleanTopic)
 	return err
 }
 
 func InviteUser(conn net.Conn, nick string, channel string) error {
-	_, err := fmt.Fprintf(conn, "INVITE "+nick+" "+channel+"\r\n")
+	_, err := fmt.Fprintf(conn, "INVITE %s %s\r\n", nick, channel)
 	log.Println("INVITE command sent for nick: ", nick, " to channel: ", channel)
 	return err
 }
@@ -49,13 +49,13 @@ func KickUser(conn net.Conn, nick string, channel string, message string) error 
 	if message == "" {
 		message = "Kicked"
 	}
-	_, err := fmt.Fprintf(conn, "KICK "+channel+" "+nick+" :"+message+"\r\n")
+	_, err := fmt.Fprintf(conn, "KICK %s %s :%s\r\n", channel, nick, message)
 	log.Println("KICK command sent for nick: ", nick, " from channel: ", channel, " with message: ", message)
 	return err
 }
 
 func Quote(conn net.Conn, command string) error {
-	_, err := fmt.Fprintf(conn, command+"\r\n")
+	_, err := fmt.Fprintf(conn, "%s\r\n", command)
 	log.Println("Sent raw command: ", command)
 	return err
 }
@@ -63,7 +63,7 @@ func Quote(conn net.Conn, command string) error {
 func SendMessage(conn net.Conn, target string, message string) error {
 	ircMessage := goutilsstrings.StripNewlines(message)
 
-	_, err := fmt.Fprintf(conn, "PRIVMSG "+target+" :"+ircMessage+"\r\n")
+	_, err := fmt.Fprintf(conn, "PRIVMSG %s :%s\r\n", target, ircMessage)
 	log.Println("Sent message to ", target, ": ", ircMessage)
 	return err
 }
@@ -71,7 +71,7 @@ func SendMessage(conn net.Conn, target string, message string) error {
 func SendNotice(conn net.Conn, target string, message string) error {
 	ircMessage := goutilsstrings.StripNewlines(message)
 
-	_, err := fmt.Fprintf(conn, "NOTICE "+target+" :"+ircMessage+"\r\n")
+	_, err := fmt.Fprintf(conn, "NOTICE %s :%s\r\n", target, ircMessage)
 	log.Println("Sent notice to ", target, ": ", ircMessage)
 	return err
 }

--- a/ircclient/handlers.go
+++ b/ircclient/handlers.go
@@ -12,7 +12,7 @@ import (
 
 func ReturnPong(connection net.Conn, message string) {
 	pongMessage := strings.Replace(message, "PING", "PONG", 1)
-	fmt.Fprintf(connection, pongMessage+"\r\n")
+	fmt.Fprintf(connection, "%s\r\n", pongMessage)
 	log.Println("PONG returned to server PING")
 }
 


### PR DESCRIPTION
## Summary

- Fixes the build failure in `ircclient` surfaced by the gin v1.12.0 upgrade (cfindlayisme/wmb#117)
- All `fmt.Fprintf` calls that used string concatenation for the format argument (e.g. `"NICK "+nick+"\r\n"`) are replaced with proper format verbs (e.g. `"NICK %s\r\n", nick`)
- Same fix applied to the PONG handler in `handlers.go`

The `go vet` printf analyzer flags non-constant format strings as errors; gin v1.12.0's bumped minimum Go version in its `go.mod` caused this to be enforced during `go test`.

## Test plan

- [ ] `go vet ./ircclient/...` passes cleanly
- [ ] CI build-test-deploy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)